### PR TITLE
bump build number

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 0
+  number: 1
 
 requirements:
   host:


### PR DESCRIPTION
Bump the build number to release updated python dependency
See the commit https://github.com/conda-forge/amazon-q-developer-jupyterlab-ext-feedstock/commit/a2e24e9e0d17736c9e319dfb312bdc6c55d061ca